### PR TITLE
Fix madmom install by adding numpy prerequisite

### DIFF
--- a/setup-dev-requirements.sh
+++ b/setup-dev-requirements.sh
@@ -334,10 +334,15 @@ download_python_dependencies() {
     # Download madmom and its dependencies
     local pip_cmd="python$PYTHON_VERSION -m pip"
     if check_command python$PYTHON_VERSION; then
-        # madmom's setup.py requires Cython for metadata generation
+        # madmom's setup.py requires Cython and numpy for metadata generation
         if ! $pip_cmd show Cython >/dev/null 2>&1; then
             log_info "Installing build dependency Cython..."
             $pip_cmd install --quiet Cython
+        fi
+
+        if ! $pip_cmd show numpy >/dev/null 2>&1; then
+            log_info "Installing build dependency numpy..."
+            $pip_cmd install --quiet numpy
         fi
 
         $pip_cmd download --dest "$OFFLINE_DIR/python/wheels" madmom numpy scipy Cython


### PR DESCRIPTION
## Summary
- install numpy before downloading madmom dependencies

## Testing
- `bash -n setup-dev-requirements.sh`
- `add-apt-repository -y ppa:deadsnakes/ppa` *(fails: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_6863f8a8b07883308da27924997edffe