### PR TITLE
Use optimized scavenger hunt builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ docker-compose.yml
 ```
 
 The container includes:
-- **Media Processing**: `ffmpeg` (5.1.6), `libheif-examples`, `yt-dlp`
+- **Media Processing**: `ffmpeg` (5.1.6), `ImageMagick`, `libheif-examples` (provides `heif-convert` for HEIC), `yt-dlp`
 - **Audio Analysis**: Python 3 with `madmom` for beat detection
 - **Shell Support**: `zsh` for script compatibility
 - **Enhanced Processing**: Optimized slideshow builders with Docker-compatible FFmpeg filters

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ file uploads, audio analysis, and slideshow processing capabilities.
 - **Project Management**: Create, organize, and manage multiple slideshow projects
 - **Multiple Project Types**: FWI Main, FWI Emotional, and Scavenger Hunt with unique interfaces
   - **Enhanced Scavenger Hunt**: 90% faster processing with professional crossfades (10-15s vs 2-3 min)
-- **Smart File Uploads**: Support for images (JPEG, PNG, HEIC) and audio files
+- **Smart File Uploads**: Support for images (JPEG, PNG, HEIC) and audio files with automatic HEIC conversion
   - **Batch Upload**: Upload up to 12 images at once for Scavenger Hunt projects
   - **Duplicate Prevention**: Automatic detection and prevention of duplicate images
 - **YouTube Integration**: Download audio directly from YouTube with time-based extraction
@@ -44,7 +44,7 @@ docker-compose.yml
 ```
 
 The container includes:
-- **Media Processing**: `ffmpeg` (5.1.6), `ImageMagick`, `libheif-examples` (provides `heif-convert` for HEIC), `yt-dlp`
+- **Media Processing**: `ffmpeg` (5.1.6), `ImageMagick`, `libheif-examples` (provides `heif-convert`), plus `ffmpeg` fallback for HEIC, `yt-dlp`
 - **Audio Analysis**: Python 3 with `madmom` for beat detection
 - **Shell Support**: `zsh` for script compatibility
 - **Enhanced Processing**: Optimized slideshow builders with Docker-compatible FFmpeg filters

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,6 +9,7 @@ ENV TZ=UTC
 RUN apt-get update && apt-get install -y \
     ffmpeg \
     imagemagick \
+    libheif-examples \
     build-essential \
     pkg-config \
     libasound2-dev \

--- a/backend/api/process.js
+++ b/backend/api/process.js
@@ -140,7 +140,7 @@ router.post('/:projectId/process', async (req, res) => {
     console.log(`Project type: ${projectType}, Audio type: ${audioType}, Has pre-generated videos: ${hasPreGeneratedVideos}`);
     let scriptName;
     if (projectType === 'Scavenger-Hunt') {
-      scriptName = hasPreGeneratedVideos ? 'scavenger_hunt_slideshow_builder.sh' : 'process_scavenger_hunt.sh';
+      scriptName = hasPreGeneratedVideos ? 'scavenger_hunt_slideshow_builder_v2.sh' : 'process_scavenger_hunt.sh';
     } else if (audioType === 'emotional') {
       scriptName = hasPreGeneratedVideos ? 'process_single_emotional_fast.sh' : 'process_single_emotional.sh';
     } else {

--- a/backend/api/uploads.js
+++ b/backend/api/uploads.js
@@ -54,7 +54,7 @@ async function convertHeicToJpg(inputPath, outputPath) {
       await runProcess('heif-convert', [inputPath, outputPath]);
       return;
     } catch (err) {
-      console.error('heif-convert failed, falling back to ImageMagick:', err.message);
+      console.error('heif-convert failed, falling back to other tools:', err.message);
     }
   }
 
@@ -64,7 +64,17 @@ async function convertHeicToJpg(inputPath, outputPath) {
       await runProcess('sips', ['-s', 'format', 'jpeg', inputPath, '--out', outputPath]);
       return;
     } catch (err) {
-      console.error('sips failed, falling back to ImageMagick:', err.message);
+      console.error('sips failed, trying ffmpeg/ImageMagick:', err.message);
+    }
+  }
+
+  // ffmpeg can also decode HEIC when built with libheif
+  if (await commandExists('ffmpeg')) {
+    try {
+      await runProcess('ffmpeg', ['-y', '-i', inputPath, outputPath]);
+      return;
+    } catch (err) {
+      console.error('ffmpeg failed, trying ImageMagick:', err.message);
     }
   }
 

--- a/docs/api/implementation.md
+++ b/docs/api/implementation.md
@@ -61,7 +61,7 @@ Created modular API structure in `backend/api/`:
 
 - Multer-based file upload with validation
 - Support for images: JPEG, PNG, HEIC
-- HEIC images are automatically converted to JPG using `heif-convert` when available (fallback to ImageMagick)
+- HEIC images are automatically converted to JPG using `heif-convert` when available, with fallbacks to `sips`, `ffmpeg`, and ImageMagick
 - Support for audio: MP3, WAV, M4A, AAC
 - YouTube URL validation
 - yt-dlp integration for audio download with time-based extraction

--- a/docs/api/implementation.md
+++ b/docs/api/implementation.md
@@ -59,9 +59,9 @@ Created modular API structure in `backend/api/`:
 - `POST /api/upload/:id/youtube-download` - Download and convert YouTube audio
 - `DELETE /api/upload/:id/files/:filename` - Delete specific files
 
-**Features:**
 - Multer-based file upload with validation
 - Support for images: JPEG, PNG, HEIC
+- HEIC images are automatically converted to JPG using `heif-convert` when available (fallback to ImageMagick)
 - Support for audio: MP3, WAV, M4A, AAC
 - YouTube URL validation
 - yt-dlp integration for audio download with time-based extraction

--- a/docs/features/scavenger-hunt.md
+++ b/docs/features/scavenger-hunt.md
@@ -13,7 +13,7 @@ YouTube audio.
 
 ## Implementation Highlights
 
-- `scavenger_hunt_slideshow_builder.sh` pre-renders short video segments and
+- `scavenger_hunt_slideshow_builder_v2.sh` pre-renders short video segments and
   stitches them together with FFmpeg crossfades for smooth transitions.
 - Timing fixes ensure the first and last images display for the correct
 duration and that the audio fades out with the final slide.


### PR DESCRIPTION
## Summary
- switch process to `scavenger_hunt_slideshow_builder_v2.sh`
- mention new builder script in docs
- add heif-convert fallback when converting HEIC files
- document HEIC conversion implementation
- install `libheif-examples` in backend Dockerfile for HEIC support

## Testing
- `npm run test:unit --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871328445e483308f1be196c42b7416